### PR TITLE
ci: Remove branch filters from workflow triggers

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,10 +1,6 @@
 name: GDS Check
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflow will now trigger on all branches for push and pull_request events, instead of being limited to the 'master' branch.