### PR TITLE
Add contributor and star history stats to docs

### DIFF
--- a/docs/about/konado.md
+++ b/docs/about/konado.md
@@ -25,3 +25,31 @@ QQ频道交流群组：https://pd.qq.com/g/GodotHub999/text/707799746
 <a href="https://godothub.com">
 <img src="https://godothub.com/licon/godothub.png" alt="godothub" style="width: 65%;" />
 </a>
+
+
+## 统计信息
+
+
+### 项目贡献者
+
+以下图表通过[contrib.rocks](https://contrib.rocks)生成，实时更新项目贡献者信息。
+
+<picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://contrib.rocks/image?repo=GodotHub/konado&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://contrib.rocks/image?repo=GodotHub/konado" />
+   <img alt="Contributors" src="https://contrib.rocks/image?repo=GodotHub/konado" />
+</picture>
+
+
+### Github Star History
+<picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GodotHub/konado&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GodotHub/konado&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GodotHub/konado&type=date&legend=top-left" />
+ </picture>
+
+
+### AtomGit Gitcode Star History
+
+![AtomGit Gitcode Star History](https://gitcode.com/godothub/konado/starcharts.svg?variant=adaptive)
+


### PR DESCRIPTION
Added sections to docs/about/konado.md displaying project contributor charts and star history using external services. This provides more visibility into project activity and community engagement.