### PR TITLE
ci: Limit workflow triggers to project-related paths

### DIFF
--- a/.github/workflows/build-test-project.yml
+++ b/.github/workflows/build-test-project.yml
@@ -3,8 +3,20 @@ on:
   push:
     branches: [ "master" ]
     tags: [ "v*" ]
+    paths:
+      - 'addons/**'
+      - 'assets/**'
+      - 'sample/**'
+      - 'export_presets.cfg'
+      - 'project.godot'
   pull_request:
     branches: [ "master" ]
+    paths:
+      - 'addons/**'
+      - 'assets/**'
+      - 'sample/**'
+      - 'export_presets.cfg'
+      - 'project.godot'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Updated the build-test-project workflow to only trigger on changes to specific project directories and files.