### PR TITLE
ci: fix build-docs.yaml

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,37 +1,98 @@
-name: Check Docs Build
+name: Build Docs
 
 on:
   push:
     branches:
+      - main
       - master
     paths:
-      - 'docs/**'
+      - "docs/**"
+      - ".github/workflows/build-docs.yaml"
   pull_request:
     branches:
+      - main
       - master
     paths:
-      - 'docs/**'
-  workflow_dispatch:
+      - "docs/**"
+      - ".github/workflows/build-docs.yaml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: vitepress-docs-deploy
+  cancel-in-progress: true
 
 jobs:
-  check-docs:
-    name: Check Docs Build
+  build-and-push:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
 
-      - name: Install dependencies
-        run: npm install
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
-      - name: Build VitePress docs
-        run: npm run docs:build
+      - name: Install deps
+        working-directory: docs
+        run: pnpm install
+
+      - name: Build VitePress
+        working-directory: docs
+        run: pnpm docs:build
+
+      - name: Deploy to docs branch (force overwrite)
+        env:
+          DOCS_BRANCH: docs
+          DIST_DIR: docs/.vitepress/dist
+        run: |
+          set -e
+
+          # 配置提交者信息（使用 Actions bot）
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # 确保产物目录存在
+          test -d "$DIST_DIR"
+
+          # 准备一个临时目录作为分支目录
+          rm -rf .deploy_docs_branch
+          mkdir -p .deploy_docs_branch
+
+          # 尝试检出 docs 分支；不存在则新建 orphan 分支
+          if git ls-remote --exit-code --heads origin "$DOCS_BRANCH" >/dev/null 2>&1; then
+            git worktree add .deploy_docs_branch "$DOCS_BRANCH"
+          else
+            git worktree add --detach .deploy_docs_branch
+            cd .deploy_docs_branch
+            git checkout --orphan "$DOCS_BRANCH"
+            # 清空 index
+            git rm -rf . >/dev/null 2>&1 || true
+            cd ..
+          fi
+
+          # 进入 worktree，清空旧内容（保留 .git 由 worktree 管）
+          cd .deploy_docs_branch
+          find . -mindepth 1 -maxdepth 1 ! -name ".git" -exec rm -rf {} +
+
+          # 拷贝构建产物到分支根目录
+          cp -R "../$DIST_DIR"/. .
+
+          # 提交并强推（覆盖历史内容）
+          git add -A
+          git commit -m "docs: deploy vitepress to $DOCS_BRANCH [skip ci]" || echo "No changes to commit"
+          git push origin "$DOCS_BRANCH" --force
+
+          cd ..
+          git worktree remove .deploy_docs_branch --force


### PR DESCRIPTION
This PR enhances the `build-docs.yaml` workflow to make it fully functional and reliable for building and deploying the documentation.

The workflow now correctly installs dependencies, builds our konado website, and deploys the generated static files to a dedicated `docs` branch. The deployment process is designed to be safe and repeatable, ensuring that the target branch always reflects the latest documentation output without carrying over stale files from previous builds.

In addition, the workflow supports both `push` and `pull_request` events for relevant documentation changes, making it easier to validate documentation updates during development. Manual triggering via `workflow_dispatch` is also supported.