### PR TITLE
chore(konado_dialogue_left): remove unused sample resource imports

### DIFF
--- a/addons/konado/template/konado_dialogue_left.tscn
+++ b/addons/konado/template/konado_dialogue_left.tscn
@@ -4,10 +4,7 @@
 [ext_resource type="Script" uid="uid://b3xcpatqnlrg" path="res://addons/konado/scripts/knd_settings_bridge.gd" id="2_m70cm"]
 [ext_resource type="Script" uid="uid://dpo124xwpder5" path="res://addons/konado/scripts/dialogue/knd_dialogue_manager.gd" id="2_tn0i2"]
 [ext_resource type="Script" uid="uid://cyoedi0x84dxy" path="res://addons/konado/scripts/act/knd_acting_interface.gd" id="3_j3lp8"]
-[ext_resource type="Resource" uid="uid://gi0knny11y78" path="res://sample/demo/new_resource.tres" id="3_k5ucr"]
-[ext_resource type="Resource" uid="uid://bf0o7uo4h3ta1" path="res://sample/demo/bg_list.tres" id="4_5t7mf"]
 [ext_resource type="PackedScene" uid="uid://b3wibk1ya0b6j" path="res://addons/konado/template/knd_dialogue_box_left.tscn" id="4_m70cm"]
-[ext_resource type="Resource" uid="uid://v3bsw26q8dli" path="res://sample/demo/bgm_list.tres" id="5_c8nf7"]
 [ext_resource type="Script" uid="uid://b0kbsxqyedoml" path="res://addons/konado/scripts/dialogue/knd_choice_interface.gd" id="5_k5ucr"]
 [ext_resource type="Script" uid="uid://gh6w15d30qe7" path="res://addons/konado/scripts/save_system/save_load_ui.gd" id="6_5t7mf"]
 [ext_resource type="Script" uid="uid://cfbojxb1pdbrs" path="res://addons/konado/scripts/audio/knd_audio_interface.gd" id="7_c8nf7"]
@@ -40,9 +37,6 @@ _acting_interface = NodePath("KonadoUI/ActingInterface")
 _audio_interface = NodePath("KonadoAudioInterface")
 _autoPlayButton = NodePath("KonadoUI/ColorRect/HBoxContainer/AutoPlay")
 _settingsButton = NodePath("KonadoUI/ColorRect/HBoxContainer/Settings")
-chara_list = ExtResource("3_k5ucr")
-background_list = ExtResource("4_5t7mf")
-bgm_list = ExtResource("5_c8nf7")
 error_tooltip_panel = NodePath("KonadoErrorToolTip")
 error_tooltip_label = NodePath("KonadoErrorToolTip/MarginContainer/ErrorText")
 error_skip_btn = NodePath("KonadoErrorToolTip/Skip")


### PR DESCRIPTION
清理了左侧对话模板中未使用的示例资源引用，移除了不再需要的chara_list、background_list和bgm_list变量定义