### PR TITLE
fix: 修复自动播放触发逻辑错误

### DIFF
--- a/addons/konado/scripts/dialogue/knd_dialogue_manager.gd
+++ b/addons/konado/scripts/dialogue/knd_dialogue_manager.gd
@@ -702,7 +702,7 @@ func start_autoplay(value: bool):
 	else:
 		_autoPlayButton.set_text("自动播放")
 	await get_tree().process_frame
-	if autoplay && dialogueState != DialogState.OFF:
+	if autoplay or dialogueState != DialogState.OFF:
 		_process_next()
 	
 	

--- a/sample/demo/demo_03_variable.ks
+++ b/sample/demo/demo_03_variable.ks
@@ -13,7 +13,7 @@ background bg1 fade
 # ============================================================
 
 actor show Kona 正常 at 3
-"Kona" "欢迎来到变量系统演示！" voice_01
+"Kona" "欢迎来到变量系统演示！"
 "Kona" "首先来看持久变量（%前缀）的操作。"
 
 actor change Kona 介绍说话


### PR DESCRIPTION
将自动播放的判断条件从&&改为or，确保在对话非自动播放状态时正确触发自动播放流程，同时移除了演示文件中多余的voice_01语音标签