### PR TITLE
chore: 删除过时的git提交信息规则文件

### DIFF
--- a/.trae/rules/git-commit-message.md
+++ b/.trae/rules/git-commit-message.md
@@ -1,7 +1,0 @@
----
-alwaysApply: true
-scene: git_message
----
-
-简体中文，和以往的提交信息一致。
-如果更新版本号：chore: 发布 Konado 2.4.4 LTS 版本


### PR DESCRIPTION
移除了项目中不再需要的.trae/rules/git-commit-message.md文件