### PR TITLE
chore: bump version to 2.6

### DIFF
--- a/addons/konado/plugin.cfg
+++ b/addons/konado/plugin.cfg
@@ -3,6 +3,6 @@
 name="Konado"
 description="Konado is a dialogue creation toolkit for the Godot Engine, with templates and a dialogue manager to help you quickly build Visual Novels, Gal Games, RPGs and other story‑driven projects."
 author="DSOE1024, putyk, ioniccrystal"
-version="2.5"
+version="2.6"
 script="konado_plugin.gd"
 icon="icon.png"


### PR DESCRIPTION
## Changes
Bump plugin version number to 2.6 in plugin.cfg.

## Test
Verified the version displays correctly in Godot plugin manager.