### PR TITLE
fix(acting interface): correct default background tint intensity value

### DIFF
--- a/addons/konado/scripts/act/knd_acting_interface.gd
+++ b/addons/konado/scripts/act/knd_acting_interface.gd
@@ -511,7 +511,7 @@ func apply_background_tint_to_characters() -> void:
 		
 	var raw_color: Color = _current_background_scene.get_scene_tint_color()
 	# 默认禁用
-	var total_intensity: float = 1.0
+	var total_intensity: float = 0.0
 	if enable_tint_intensity:
 		total_intensity = clamp(global_tint_intensity * _current_background_scene.scene_tint_intensity, 0.0, 1.0)
 	var tint_color: Color = Color.WHITE.lerp(raw_color, total_intensity)


### PR DESCRIPTION
修正了角色背景着色效果的默认强度初始值，将原本的1.0改为0.0，匹配注释里的默认禁用描述