### PR TITLE
feat: Refactor background transition with viewport capture detection

### DIFF
--- a/addons/konado/scripts/background/knd_background_scene_base.gd
+++ b/addons/konado/scripts/background/knd_background_scene_base.gd
@@ -73,18 +73,16 @@ func _collect_capture_state(node: Node, is_root: bool, state: Dictionary) -> voi
 		# 不可见分支不参与最终画面，整棵子树直接跳过。
 		if not canvas_item.visible:
 			return
+		# 命中任一"必须走 SubViewport"的条件即标记 capture，
+		# 用 elif 链收敛出口，避免在每个分支里各 return 一次。
 		if canvas_item.material != null:
 			state["capture"] = true
-			return
-		if canvas_item.self_modulate != Color.WHITE:
+		elif canvas_item.self_modulate != Color.WHITE:
 			state["capture"] = true
-			return
 		# 根节点的 modulate 由转场层统一接管，只检查子节点上的染色。
-		if not is_root and canvas_item.modulate != Color.WHITE:
+		elif not is_root and canvas_item.modulate != Color.WHITE:
 			state["capture"] = true
-			return
-
-		if canvas_item is TextureRect:
+		elif canvas_item is TextureRect:
 			var texture_rect := canvas_item as TextureRect
 			if (
 				texture_rect.stretch_mode != TextureRect.STRETCH_SCALE
@@ -92,8 +90,7 @@ func _collect_capture_state(node: Node, is_root: bool, state: Dictionary) -> voi
 				or texture_rect.flip_v
 			):
 				state["capture"] = true
-				return
-			if texture_rect.texture:
+			elif texture_rect.texture:
 				state["drawables"] += 1
 		elif canvas_item is Sprite2D:
 			if (canvas_item as Sprite2D).texture:
@@ -102,18 +99,19 @@ func _collect_capture_state(node: Node, is_root: bool, state: Dictionary) -> voi
 			state["drawables"] += 1
 		elif canvas_item is AnimatedSprite2D or canvas_item is VideoStreamPlayer:
 			state["capture"] = true
-			return
 	elif node is AnimationPlayer:
 		var player := node as AnimationPlayer
 		# shader 转场期间不会调用 play_enter / play_exit，
 		# 只有自动播放或已在播放的动画才会让画面持续变化。
 		if player.is_playing() or not player.autoplay.is_empty():
 			state["capture"] = true
-			return
 	elif node is AnimationTree:
 		if (node as AnimationTree).active:
 			state["capture"] = true
-			return
+
+	# 一旦命中 capture，当前节点不再下探子节点（与原有提前 return 等价）。
+	if bool(state["capture"]):
+		return
 
 	for child in node.get_children():
 		_collect_capture_state(child, false, state)

--- a/addons/konado/scripts/background/knd_background_scene_base.gd
+++ b/addons/konado/scripts/background/knd_background_scene_base.gd
@@ -47,8 +47,78 @@ func setup_background(_background_name: String, _params: Dictionary = {}) -> voi
 ## 给系统内置 shader 转场使用的静态纹理。
 ## 图片背景默认会递归寻找第一个 TextureRect / Sprite2D；视频、Live2D、Spine 等动态场景可保持为空，
 ## 交给 KND_BackgroundTransitionLayer 使用 SubViewport 渲染。
+## 注意：这里返回的是原始纹理资源，不包含 modulate、材质 shader 等场景内的表现。
 func get_transition_texture() -> Texture2D:
 	return _find_transition_texture(self)
+
+
+## 系统内置 shader 转场是否必须整场景渲染（SubViewport 捕获）。
+## 静态纹理快速通道成立的前提是「整个场景在视觉上等价于那张原始纹理」。
+## 一旦场景里存在 modulate / self_modulate 染色、材质 shader、多个可绘制节点、
+## 自动播放的动画等，就必须走 SubViewport，否则这些表现会在转场期间整体丢失。
+func requires_viewport_capture() -> bool:
+	var state := {"drawables": 0, "capture": false}
+	_collect_capture_state(self, true, state)
+	if bool(state["capture"]):
+		return true
+	return int(state["drawables"]) > 1
+
+
+func _collect_capture_state(node: Node, is_root: bool, state: Dictionary) -> void:
+	if bool(state["capture"]):
+		return
+
+	if node is CanvasItem:
+		var canvas_item := node as CanvasItem
+		# 不可见分支不参与最终画面，整棵子树直接跳过。
+		if not canvas_item.visible:
+			return
+		if canvas_item.material != null:
+			state["capture"] = true
+			return
+		if canvas_item.self_modulate != Color.WHITE:
+			state["capture"] = true
+			return
+		# 根节点的 modulate 由转场层统一接管，只检查子节点上的染色。
+		if not is_root and canvas_item.modulate != Color.WHITE:
+			state["capture"] = true
+			return
+
+		if canvas_item is TextureRect:
+			var texture_rect := canvas_item as TextureRect
+			if (
+				texture_rect.stretch_mode != TextureRect.STRETCH_SCALE
+				or texture_rect.flip_h
+				or texture_rect.flip_v
+			):
+				state["capture"] = true
+				return
+			if texture_rect.texture:
+				state["drawables"] += 1
+		elif canvas_item is Sprite2D:
+			if (canvas_item as Sprite2D).texture:
+				state["drawables"] += 1
+		elif canvas_item is ColorRect or canvas_item is NinePatchRect:
+			state["drawables"] += 1
+		elif canvas_item is AnimatedSprite2D or canvas_item is VideoStreamPlayer:
+			state["capture"] = true
+			return
+	elif node is AnimationPlayer:
+		var player := node as AnimationPlayer
+		# shader 转场期间不会调用 play_enter / play_exit，
+		# 只有自动播放或已在播放的动画才会让画面持续变化。
+		if player.is_playing() or not player.autoplay.is_empty():
+			state["capture"] = true
+			return
+	elif node is AnimationTree:
+		if (node as AnimationTree).active:
+			state["capture"] = true
+			return
+
+	for child in node.get_children():
+		_collect_capture_state(child, false, state)
+		if bool(state["capture"]):
+			return
 
 
 func play_enter(effect_name: String = "none", params: Dictionary = {}) -> void:

--- a/addons/konado/scripts/background/knd_background_transition_layer.gd
+++ b/addons/konado/scripts/background/knd_background_transition_layer.gd
@@ -128,24 +128,27 @@ func play_transition(
 	visible = true
 	_shader_rect.visible = false
 
-	var current_texture := _get_transition_texture(_old_background)
-	var target_texture := _get_transition_texture(_new_background)
-	if target_texture and (current_texture or _old_background == null):
-		_start_shader_transition_with_textures(
-			effect_name,
-			current_texture if current_texture else _get_fallback_texture(),
-			target_texture
-		)
-		return
+	# 静态纹理快速通道只有在两边背景都「视觉上等价于一张原始纹理」时才成立。
+	# 否则必须用 SubViewport 整场景渲染，否则背景内部的 modulate 染色、
+	# 子节点的材质 shader 等表现会在转场期间全部丢失，转场结束时又突然跳回来。
+	if (
+		not _requires_viewport_capture(_old_background)
+		and not _requires_viewport_capture(_new_background)
+	):
+		var current_texture := _get_transition_texture(_old_background)
+		var target_texture := _get_transition_texture(_new_background)
+		if target_texture and (current_texture or _old_background == null):
+			_start_shader_transition_with_textures(
+				effect_name,
+				current_texture if current_texture else _get_fallback_texture(),
+				target_texture
+			)
+			return
 
 	_prepare_viewport_root(_current_root)
 	_prepare_viewport_root(_target_root)
-	if _old_background:
-		_move_background_to_root(_old_background, _current_root)
-	else:
-		_current_root.add_child(_current_fallback)
-		_set_full_rect(_current_fallback, _current_viewport.size)
-		_current_fallback.show()
+	# 新背景先进 SubViewport 预热，旧背景此时仍留在舞台上，
+	# 避免转场真正开始前舞台空出来闪几帧黑。
 	_move_background_to_root(_new_background, _target_root)
 
 	call_deferred("_start_shader_transition", effect_name)
@@ -237,6 +240,14 @@ func _create_viewport_root(node_name: String) -> Control:
 func _prepare_viewport_root(root: Control) -> void:
 	for child in root.get_children():
 		root.remove_child(child)
+		# 清掉上一次转场可能残留的孤儿节点，_current_fallback 和本次参与转场的背景除外。
+		if (
+			child != _current_fallback
+			and child != _old_background
+			and child != _new_background
+			and is_instance_valid(child)
+		):
+			child.queue_free()
 	_set_full_rect(root, _get_transition_size())
 
 
@@ -257,6 +268,20 @@ func _start_shader_transition(effect_name: String) -> void:
 	await get_tree().process_frame
 	if not _is_transitioning:
 		return
+
+	# 旧背景拖到最后一刻才移入 SubViewport。SubViewport 会在父视口之前渲染，
+	# 所以本帧显示 shader_rect 时 current_texture 已经是正确内容，舞台不会闪黑。
+	if _old_background and is_instance_valid(_old_background):
+		_move_background_to_root(_old_background, _current_root)
+	else:
+		var fallback_parent := _current_fallback.get_parent()
+		if fallback_parent != _current_root:
+			if fallback_parent:
+				fallback_parent.remove_child(_current_fallback)
+			_current_root.add_child(_current_fallback)
+		_set_full_rect(_current_fallback, _current_viewport.size)
+		_current_fallback.show()
+
 	var config: Dictionary = TRANSITION_CONFIGS[effect_name]
 	_shader_material.shader = config["shader"]
 	_shader_material.set_shader_parameter("progress", 0.0)
@@ -286,10 +311,11 @@ func _play_shader_tween(config: Dictionary) -> void:
 		_finish_shader_transition()
 		return
 	_transition_tween = create_tween()
+	# set_trans 只影响之后创建的 tweener，必须放在 tween_property 之前。
+	_transition_tween.set_trans(config["tween_trans"])
 	_transition_tween.tween_property(
 		_shader_material, "shader_parameter/progress", progress_target, duration
 	)
-	_transition_tween.set_trans(config["tween_trans"])
 	_transition_tween.finished.connect(_finish_shader_transition, ConnectFlags.CONNECT_ONE_SHOT)
 
 
@@ -340,6 +366,12 @@ func _get_transition_texture(background: KND_BackgroundSceneBase) -> Texture2D:
 	if background == null:
 		return null
 	return background.get_transition_texture()
+
+
+func _requires_viewport_capture(background: KND_BackgroundSceneBase) -> bool:
+	if background == null:
+		return false
+	return background.requires_viewport_capture()
 
 
 func _get_fallback_texture() -> Texture2D:


### PR DESCRIPTION
add requires_viewport_capture check to determine if shader transition needs full viewport capture, rewrite transition logic to use fast texture path only when both backgrounds support it, fix staging flash issues and clean up orphaned viewport nodes